### PR TITLE
ENG-3746: Add workflow to auto-close stale PRs

### DIFF
--- a/.github/workflows/close-stale-prs.yml
+++ b/.github/workflows/close-stale-prs.yml
@@ -31,17 +31,17 @@ jobs:
 
               console.log(`Closing PR #${pr.number}: "${pr.title}" (last activity ${pr.updated_at})`);
 
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: pr.number,
-                body: '🤖 This PR was automatically closed because it had no activity for more than 7 days.',
-              });
-
               await github.rest.pulls.update({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 pull_number: pr.number,
                 state: 'closed',
+              });
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body: '🤖 This PR was automatically closed because it had no activity for more than 7 days.',
               });
             }

--- a/.github/workflows/close-stale-prs.yml
+++ b/.github/workflows/close-stale-prs.yml
@@ -1,0 +1,47 @@
+name: Close Stale PRs
+
+on:
+  schedule:
+    - cron: '0 9 * * *' # daily at 9:00 UTC
+  workflow_dispatch: # allow manual trigger
+
+jobs:
+  close-stale-prs:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Close PRs older than 7 days
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const cutoff = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+
+            const prs = await github.paginate(github.rest.pulls.list, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              sort: 'updated',
+              direction: 'asc',
+            });
+
+            for (const pr of prs) {
+              const updatedAt = new Date(pr.updated_at);
+              if (updatedAt >= cutoff) continue;
+
+              console.log(`Closing PR #${pr.number}: "${pr.title}" (last activity ${pr.updated_at})`);
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body: '🤖 This PR was automatically closed because it had no activity for more than 7 days.',
+              });
+
+              await github.rest.pulls.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+                state: 'closed',
+              });
+            }


### PR DESCRIPTION
Adds a GitHub Actions workflow that automatically closes PRs with no activity for more than 7 days.

Runs daily at 9:00 UTC and can also be triggered manually.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Automatically closes open PRs based on last update time, which can unexpectedly shut down active-but-quiet work if the 7-day cutoff or permissions are misconfigured. Limited to GitHub Actions automation (no production code changes), but affects repository contribution flow.
> 
> **Overview**
> Adds a new GitHub Actions workflow (`.github/workflows/close-stale-prs.yml`) that runs daily (and on manual trigger) to find open PRs with no activity for 7+ days and automatically close them.
> 
> The workflow uses `actions/github-script@v7` to paginate PRs sorted by oldest update, closes qualifying PRs, and posts an explanatory comment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 055dcd7a4b21f545a01a7f67d5f9605a03b9cf9d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->