### PR TITLE
release: publish 1.1.0 to Community Template Gallery

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,17 @@
 homepage: "https://podscribe.com"
 documentation: "https://help.podscribe.com/sending-podscribe-conversion-events-/g4g8w3hppouCfkXZdcx6FV/sending-events-via-google-tag-manager-gtm/3mDBt8JpG3wncH11tpMVZw"
 versions:
+  - sha: 8c367011492d04463dcdefd234f7f7f1ae8c20c9
+    version: 1.1.0
+    changeNotes: |
+      - Expose order_number, discount_code, and value on signup and lead
+        events (via the More Fields group, using internal *_ext keys so the
+        top-level purchase layout is unchanged).
+      - Add Custom Parameters (SIMPLE_TABLE) for arbitrary key / value pairs
+        on purchase, signup, and lead events — forwarded as-is to the
+        Podscribe pixel.
+      - Add template test scenarios covering every event type and field
+        combination.
   - sha: c69901f2aec604fa3aa6aef65e864576f7560396
     version: 1.0.0
     changeNotes: Initial release of Podscribe conversion tag template.


### PR DESCRIPTION
## Summary
Point the Google Community Template Gallery crawler at the squash-merge of #3 (`8c367011`) so GTM users see version 1.1.0 in their Template Editor history. The \`___INFO___.version\` field in \`template.tpl\` was already bumped to \`2\` as part of #3.

## Changes in 1.1.0
- Expose \`order_number\`, \`discount_code\`, and \`value\` on signup and lead events via the More Fields group (internal \`*_ext\` keys — top-level purchase layout unchanged).
- Add Custom Parameters (\`SIMPLE_TABLE\`) for arbitrary key / value pairs on purchase, signup, and lead events, forwarded as-is to the Podscribe pixel.
- Add \`___TESTS___\` scenarios covering every event type and field combination (7 tests, all passing in Template Editor).

## Post-merge
1. Tag the commit: \`git tag v1.1.0 <merge-sha> && git push origin v1.1.0\`
2. Create a GitHub Release with the same change notes.
3. Wait 24-72h for Google's crawler to index the new metadata.yaml entry and surface it in the Community Template Gallery.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates `metadata.yaml` to reference a new released version and its changelog; no runtime/template logic changes.
> 
> **Overview**
> Updates `metadata.yaml` to publish template version **1.1.0** by adding a new `versions` entry pointing to sha `8c367011...` with release notes (additional exposed fields for signup/lead, support for custom parameters, and expanded test scenarios).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85d7d8d1fb5b4ffb9a2b78c628b86a2e77e72155. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->