### PR TITLE
fix: revert ___INFO___.version to 1

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -11,7 +11,7 @@ ___INFO___
 {
   "type": "TAG",
   "id": "cvt_temp_public_id",
-  "version": 2,
+  "version": 1,
   "securityGroups": [],
   "displayName": "Podscribe",
   "categories": [


### PR DESCRIPTION
GTM template editor requires `___INFO___.version` to be 0 or 1 (it's a schema version, not a release version). My bump to 2 in #3 broke the gallery sync with "Version must be 1 or 0 (default)".

Release versioning for the Community Template Gallery is driven entirely by `metadata.yaml` (version string + SHA), so `___INFO___.version` stays at 1 forever.

After merge I'll update `metadata.yaml` to point 1.1.0 at the new fix SHA and re-tag `v1.1.0`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line metadata change that restores GTM Community Template Gallery schema compatibility and does not affect runtime tag behavior.
> 
> **Overview**
> Reverts `template.tpl` `___INFO___.version` from `2` back to `1` to match the GTM template schema requirements (0/1) and unblock Community Template Gallery sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bc83294676f4e2eebf12e5dc2f3e98df990b31a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->