### PR TITLE
release: point 1.1.0 at 0a4829e (___INFO___.version fix)

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,7 +1,7 @@
 homepage: "https://podscribe.com"
 documentation: "https://help.podscribe.com/sending-podscribe-conversion-events-/g4g8w3hppouCfkXZdcx6FV/sending-events-via-google-tag-manager-gtm/3mDBt8JpG3wncH11tpMVZw"
 versions:
-  - sha: 8c367011492d04463dcdefd234f7f7f1ae8c20c9
+  - sha: 0a4829e77d4e8dd5a085940758fb24d7f66a80e0
     version: 1.1.0
     changeNotes: |
       - Expose order_number, discount_code, and value on signup and lead


### PR DESCRIPTION
Previous 1.1.0 metadata entry referenced 8c36701 which had `___INFO___.version = 2`. GTM Gallery parser rejected it with 'Failed to parse the TPL content' (the schema version field only accepts 0 or 1).

This PR points 1.1.0 at 0a4829e instead (the fix from #5).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk metadata-only change that updates the referenced template commit; main risk is accidentally pointing to the wrong SHA and breaking the release artifact.
> 
> **Overview**
> Repoints the `metadata.yaml` `1.1.0` release entry from SHA `8c36701…` to `0a4829e…`, ensuring the published template references the commit with the corrected `___INFO___.version` value so GTM Gallery accepts the upload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed675a10ec29d222301b5204debefbd2b4361f98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->